### PR TITLE
Add unit tests for org.rapidpm.frp.model

### DIFF
--- a/src/main/java/org/rapidpm/frp/model/Sext.java
+++ b/src/main/java/org/rapidpm/frp/model/Sext.java
@@ -136,12 +136,13 @@ public class Sext<T1, T2, T3, T4, T5, T6> {
   /** {@inheritDoc} */
   @Override
   public String toString() {
-    return "Quint{" +
+    return "Sext{" +
         "t1=" + t1 +
         ", t2=" + t2 +
         ", t3=" + t3 +
         ", t4=" + t4 +
         ", t5=" + t5 +
+        ", t6=" + t6 +
         '}';
   }
 

--- a/src/test/java/junit/org/rapidpm/frp/model/PairTest.java
+++ b/src/test/java/junit/org/rapidpm/frp/model/PairTest.java
@@ -1,0 +1,46 @@
+package junit.org.rapidpm.frp.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.rapidpm.frp.model.Pair;
+
+public class PairTest {
+
+  @Test
+  public void testEquals() {
+    final Pair pair = new Pair(0, 1);
+
+    assertFalse(pair.equals(null));
+    assertFalse(pair.equals(new Pair(null, 1)));
+    assertFalse(pair.equals(new Pair(0, null)));
+    assertTrue(pair.equals(pair));
+    assertTrue(pair.equals(new Pair(0, 1)));
+  }
+
+  @Test
+  public void testHashCode() {
+    final Pair pair = new Pair(0, 1);
+
+    assertEquals(962, pair.hashCode());
+  }
+
+  @Test
+  public void testNext() {
+    final Pair pair = Pair.next(0, 1);
+
+    assertNotNull(pair);
+    assertEquals(0, pair.getT1());
+    assertEquals(1, pair.getT2());
+  }
+
+  @Test
+  public void testToString() {
+    final Pair pair = new Pair(0, 1);
+
+    assertEquals("Pair{t1=0, t2=1}", pair.toString());
+  }
+}

--- a/src/test/java/junit/org/rapidpm/frp/model/QuadTest.java
+++ b/src/test/java/junit/org/rapidpm/frp/model/QuadTest.java
@@ -1,0 +1,109 @@
+package junit.org.rapidpm.frp.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.rapidpm.frp.model.Quad;
+
+public class QuadTest {
+
+  @Test
+  public void testEquals() {
+    final Quad quad = new Quad(0, 1, 2, 3);
+
+    assertTrue(quad.equals(quad));
+    assertFalse(quad.equals(null));
+    assertFalse(quad.equals(new Quad(null, 1, 2, 3)));
+    assertFalse(quad.equals(new Quad(0, null, 2, 3)));
+    assertFalse(quad.equals(new Quad(0, 1, null, 3)));
+  }
+
+  @Test
+  public void testEqualsT1() {
+    final Quad quad = new Quad(null, 1, 2, 3);
+
+    assertTrue(quad.equals(new Quad(null, 1, 2, 3)));
+    assertFalse(quad.equals(new Quad(0, 1, 2, 3)));
+  }
+
+  @Test
+  public void testEqualsT2() {
+    final Quad quad = new Quad(0, null, 2, 3);
+
+    assertTrue(quad.equals(new Quad(0, null, 2, 3)));
+    assertFalse(quad.equals(new Quad(0, 1, 2, 3)));
+  }
+
+  @Test
+  public void testEqualsT3() {
+    final Quad quad = new Quad(0, 1, null, 3);
+
+    assertTrue(quad.equals(new Quad(0, 1, null, 3)));
+    assertFalse(quad.equals(new Quad(0, 1, 2, 3)));
+  }
+
+  @Test
+  public void testEqualsT4() {
+    final Quad quad = new Quad(0, 1, 2, null);
+
+    assertTrue(quad.equals(new Quad(0, 1, 2, null)));
+    assertFalse(quad.equals(new Quad(0, 1, 2, 3)));
+  }
+
+  @Test
+  public void testHashCode() {
+    final Quad quad = new Quad(0, 1, 2, 3);
+
+    assertEquals(1026, quad.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT1() {
+    final Quad quad = new Quad(null, 1, 2, 3);
+
+    assertEquals(1026, quad.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT2() {
+    final Quad quad = new Quad(0, null, 2, 3);
+
+    assertEquals(65, quad.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT3() {
+    final Quad quad = new Quad(0, 1, null, 3);
+
+    assertEquals(964, quad.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT4() {
+    final Quad quad = new Quad(0, 1, 2, null);
+
+    assertEquals(1023, quad.hashCode());
+  }
+
+
+  @Test
+  public void testNext() {
+    final Quad quad = Quad.next(0, 1, 2, 3);
+
+    assertNotNull(quad);
+    assertEquals(0, quad.getT1());
+    assertEquals(1, quad.getT2());
+    assertEquals(2, quad.getT3());
+    assertEquals(3, quad.getT4());
+  }
+
+  @Test
+  public void testToString() {
+    final Quad quad = new Quad(0, 1, 2, 3);
+
+    assertEquals("Quad{t1=0, t2=1, t3=2, t4=3}", quad.toString());
+  }
+}

--- a/src/test/java/junit/org/rapidpm/frp/model/QuintTest.java
+++ b/src/test/java/junit/org/rapidpm/frp/model/QuintTest.java
@@ -1,0 +1,125 @@
+package junit.org.rapidpm.frp.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.rapidpm.frp.model.Quint;
+
+public class QuintTest {
+
+  @Test
+  public void testEquals() {
+    final Quint quint = new Quint(0, 1, 2, 3, 4);
+
+    assertTrue(quint.equals(quint));
+    assertFalse(quint.equals(null));
+    assertFalse(quint.equals(new Quint(null, 1, 2, 3, 4)));
+    assertFalse(quint.equals(new Quint(0, null, 2, 3, 4)));
+    assertFalse(quint.equals(new Quint(0, 1, null, 3, 4)));
+    assertFalse(quint.equals(new Quint(0, 1, 2, null, 4)));
+  }
+
+  @Test
+  public void testEqualsT1() {
+    final Quint quint = new Quint(null, 1, 2, 3, 4);
+
+    assertTrue(quint.equals(new Quint(null, 1, 2, 3, 4)));
+    assertFalse(quint.equals(new Quint(0, 1, 2, 3, 4)));
+  }
+
+  @Test
+  public void testEqualsT2() {
+    final Quint quint = new Quint(0, null, 2, 3, 4);
+
+    assertTrue(quint.equals(new Quint(0, null, 2, 3, 4)));
+    assertFalse(quint.equals(new Quint(0, 1, 2, 3, 4)));
+  }
+
+  @Test
+  public void testEqualsT3() {
+    final Quint quint = new Quint(0, 1, null, 3, 4);
+
+    assertTrue(quint.equals(new Quint(0, 1, null, 3, 4)));
+    assertFalse(quint.equals(new Quint(0, 1, 2, 3, 4)));
+  }
+
+  @Test
+  public void testEqualsT4() {
+    final Quint quint = new Quint(0, 1, 2, null, 4);
+
+    assertTrue(quint.equals(new Quint(0, 1, 2, null, 4)));
+    assertFalse(quint.equals(new Quint(0, 1, 2, 3, 4)));
+  }
+
+  @Test
+  public void testEqualsT5() {
+    final Quint quint = new Quint(0, 1, 2, 3, null);
+
+    assertTrue(quint.equals(new Quint(0, 1, 2, 3, null)));
+    assertFalse(quint.equals(new Quint(0, 1, 2, 3, 4)));
+  }
+
+  @Test
+  public void testHashCode() {
+    final Quint quint = new Quint(0, 1, 2, 3, 4);
+
+    assertEquals(31810, quint.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT1() {
+    final Quint quint = new Quint(null, 1, 2, 3, 4);
+
+    assertEquals(31810, quint.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT2() {
+    final Quint quint = new Quint(0, null, 2, 3, 4);
+
+    assertEquals(2019, quint.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT3() {
+    final Quint quint = new Quint(0, 1, null, 3, 4);
+
+    assertEquals(29888, quint.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT4() {
+    final Quint quint = new Quint(0, 1, 2, null, 4);
+
+    assertEquals(31717, quint.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT5() throws Exception {
+    final Quint quint = new Quint(0, 1, 2, 3, null);
+
+    assertEquals(31806, quint.hashCode());
+  }
+
+  @Test
+  public void testNext() {
+    final Quint quint = Quint.next(0, 1, 2, 3, 4);
+
+    assertNotNull(quint);
+    assertEquals(0, quint.getT1());
+    assertEquals(1, quint.getT2());
+    assertEquals(2, quint.getT3());
+    assertEquals(3, quint.getT4());
+    assertEquals(4, quint.getT5());
+  }
+
+  @Test
+  public void testToString() {
+    final Quint quint = new Quint(0, 1, 2, 3, 4);
+
+    assertEquals("Quint{t1=0, t2=1, t3=2, t4=3, t5=4}", quint.toString());
+  }
+}

--- a/src/test/java/junit/org/rapidpm/frp/model/SeptTest.java
+++ b/src/test/java/junit/org/rapidpm/frp/model/SeptTest.java
@@ -1,0 +1,159 @@
+package junit.org.rapidpm.frp.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.rapidpm.frp.model.Sept;
+
+public class SeptTest {
+
+  @Test
+  public void testEquals() {
+    final Sept sept = new Sept(0, 1, 2, 3, 4, 5, 6);
+
+    assertTrue(sept.equals(sept));
+    assertFalse(sept.equals(null));
+    assertFalse(sept.equals(new Sept(null, 1, 2, 3, 4, 5, 6)));
+    assertFalse(sept.equals(new Sept(0, null, 2, 3, 4, 5, 6)));
+    assertFalse(sept.equals(new Sept(0, 1, null, 3, 4, 5, 6)));
+    assertFalse(sept.equals(new Sept(0, 1, 2, null, 4, 5, 6)));
+    assertFalse(sept.equals(new Sept(0, 1, 2, 3, null, 5, 6)));
+    assertFalse(sept.equals(new Sept(0, 1, 2, 3, 4, null, 6)));
+  }
+
+  @Test
+  public void testEqualsT1() {
+    final Sept sept = new Sept(null, 1, 2, 3, 4, 5, 6);
+
+    assertTrue(sept.equals(new Sept(null, 1, 2, 3, 4, 5, 6)));
+    assertFalse(sept.equals(new Sept(0, 1, 2, 3, 4, 5, 6)));
+  }
+
+  @Test
+  public void testEqualsT2() {
+    final Sept sept = new Sept(0, null, 2, 3, 4, 5, 6);
+
+    assertTrue(sept.equals(new Sept(0, null, 2, 3, 4, 5, 6)));
+    assertFalse(sept.equals(new Sept(0, 1, 2, 3, 4, 5, 6)));
+  }
+
+  @Test
+  public void testEqualsT3() {
+    final Sept sept = new Sept(0, 1, null, 3, 4, 5, 6);
+
+    assertTrue(sept.equals(new Sept(0, 1, null, 3, 4, 5, 6)));
+    assertFalse(sept.equals(new Sept(0, 1, 2, 3, 4, 5, 6)));
+  }
+
+  @Test
+  public void testEqualsT4() {
+    final Sept sept = new Sept(0, 1, 2, null, 4, 5, 6);
+
+    assertTrue(sept.equals(new Sept(0, 1, 2, null, 4, 5, 6)));
+    assertFalse(sept.equals(new Sept(0, 1, 2, 3, 4, 5, 6)));
+  }
+
+  @Test
+  public void testEqualsT5() {
+    final Sept sept = new Sept(0, 1, 2, 3, null, 5, 6);
+
+    assertTrue(sept.equals(new Sept(0, 1, 2, 3, null, 5, 6)));
+    assertFalse(sept.equals(new Sept(0, 1, 2, 3, 4, 5, 6)));
+  }
+
+  @Test
+  public void testEqualsT6() {
+    final Sept sept = new Sept(0, 1, 2, 3, 4, null, 6);
+
+    assertTrue(sept.equals(new Sept(0, 1, 2, 3, 4, null, 6)));
+    assertFalse(sept.equals(new Sept(0, 1, 2, 3, 4, 5, 6)));
+  }
+
+  @Test
+  public void testEqualsT7() {
+    final Sept sept = new Sept(0, 1, 2, 3, 4, 5, null);
+
+    assertTrue(sept.equals(new Sept(0, 1, 2, 3, 4, 5, null)));
+    assertFalse(sept.equals(new Sept(0, 1, 2, 3, 4, 5, 6)));
+  }
+
+  @Test
+  public void testHashCode() {
+    final Sept sept = new Sept(0, 1, 2, 3, 4, 5, 6);
+
+    assertEquals(30569571, sept.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT1() {
+    final Sept sept = new Sept(null, 1, 2, 3, 4, 5, 6);
+
+    assertEquals(30569571, sept.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT2() {
+    final Sept sept = new Sept(0, null, 2, 3, 4, 5, 6);
+
+    assertEquals(1940420, sept.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT3() {
+    final Sept sept = new Sept(0, 1, null, 3, 4, 5, 6);
+
+    assertEquals(28722529, sept.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT4() {
+    final Sept sept = new Sept(0, 1, 2, null, 4, 5, 6);
+
+    assertEquals(30480198, sept.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT5() {
+    final Sept sept = new Sept(0, 1, 2, 3, null, 5, 6);
+
+    assertEquals(30565727, sept.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT6() {
+    final Sept sept = new Sept(0, 1, 2, 3, 4, null, 6);
+
+    assertEquals(30569416, sept.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT7() {
+    final Sept sept = new Sept(0, 1, 2, 3, 4, 5, null);
+
+    assertEquals(30569565, sept.hashCode());
+  }
+
+  @Test
+  public void testNext() {
+    final Sept sept = Sept.next(0, 1, 2, 3, 4, 5, 6);
+
+    assertNotNull(sept);
+    assertEquals(0, sept.getT1());
+    assertEquals(1, sept.getT2());
+    assertEquals(2, sept.getT3());
+    assertEquals(3, sept.getT4());
+    assertEquals(4, sept.getT5());
+    assertEquals(5, sept.getT6());
+    assertEquals(6, sept.getT7());
+  }
+
+  @Test
+  public void testToString() {
+    final Sept sept = new Sept(0, 1, 2, 3, 4, 5, 6);
+
+    assertEquals("Sept{t1=0, t2=1, t3=2, t4=3, t5=4, t6=5, t7=6}", sept.toString());
+  }
+}

--- a/src/test/java/junit/org/rapidpm/frp/model/SextTest.java
+++ b/src/test/java/junit/org/rapidpm/frp/model/SextTest.java
@@ -1,0 +1,142 @@
+package junit.org.rapidpm.frp.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.rapidpm.frp.model.Sext;
+
+public class SextTest {
+
+  @Test
+  public void testEquals() {
+    final Sext sext = new Sext(0, 1, 2, 3, 4, 5);
+
+    assertTrue(sext.equals(sext));
+    assertFalse(sext.equals(null));
+    assertFalse(sext.equals(new Sext(null, 1, 2, 3, 4, 5)));
+    assertFalse(sext.equals(new Sext(0, null, 2, 3, 4, 5)));
+    assertFalse(sext.equals(new Sext(0, 1, null, 3, 4, 5)));
+    assertFalse(sext.equals(new Sext(0, 1, 2, null, 4, 5)));
+    assertFalse(sext.equals(new Sext(0, 1, 2, 3, null, 5)));
+  }
+
+  @Test
+  public void testEqualsT1() {
+    final Sext sext = new Sext(null, 1, 2, 3, 4, 5);
+
+    assertTrue(sext.equals(new Sext(null, 1, 2, 3, 4, 5)));
+    assertFalse(sext.equals(new Sext(0, 1, 2, 3, 4, 5)));
+  }
+
+  @Test
+  public void testEqualsT2() {
+    final Sext sext = new Sext(0, null, 2, 3, 4, 5);
+
+    assertTrue(sext.equals(new Sext(0, null, 2, 3, 4, 5)));
+    assertFalse(sext.equals(new Sext(0, 1, 2, 3, 4, 5)));
+  }
+
+  @Test
+  public void testEqualsT3() {
+    final Sext sext = new Sext(0, 1, null, 3, 4, 5);
+
+    assertTrue(sext.equals(new Sext(0, 1, null, 3, 4, 5)));
+    assertFalse(sext.equals(new Sext(0, 1, 2, 3, 4, 5)));
+  }
+
+  @Test
+  public void testEqualsT4() {
+    final Sext sext = new Sext(0, 1, 2, null, 4, 5);
+
+    assertTrue(sext.equals(new Sext(0, 1, 2, null, 4, 5)));
+    assertFalse(sext.equals(new Sext(0, 1, 2, 3, 4, 5)));
+  }
+
+  @Test
+  public void testEqualsT5() {
+    final Sext sext = new Sext(0, 1, 2, 3, null, 5);
+
+    assertTrue(sext.equals(new Sext(0, 1, 2, 3, null, 5)));
+    assertFalse(sext.equals(new Sext(0, 1, 2, 3, 4, 5)));
+  }
+
+  @Test
+  public void testEqualsT6() {
+    final Sext sext = new Sext(0, 1, 2, 3, 4, null);
+
+    assertTrue(sext.equals(new Sext(0, 1, 2, 3, 4, null)));
+    assertFalse(sext.equals(new Sext(0, 1, 2, 3, 4, 5)));
+  }
+
+  @Test
+  public void testHashCode() {
+    final Sext sext = new Sext(0, 1, 2, 3, 4, 5);
+
+    assertEquals(986115, sext.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT1() {
+    final Sext sext = new Sext(null, 1, 2, 3, 4, 5);
+
+    assertEquals(986115, sext.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT2() {
+    final Sext sext = new Sext(0, null, 2, 3, 4, 5);
+
+    assertEquals(62594, sext.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT3() {
+    final Sext sext = new Sext(0, 1, null, 3, 4, 5);
+
+    assertEquals(926533, sext.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT4(){
+    final Sext sext = new Sext(0, 1, 2, null, 4, 5);
+
+    assertEquals(983232, sext.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT5() {
+    final Sext sext = new Sext(0, 1, 2, 3, null, 5);
+
+    assertEquals(985991, sext.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT6() {
+    final Sext sext = new Sext(0, 1, 2, 3, 4, null);
+
+    assertEquals(986110, sext.hashCode());
+  }
+
+  @Test
+  public void testNext() {
+    final Sext sext = Sext.next(0, 1, 2, 3, 4, 5);
+
+    assertNotNull(sext);
+    assertEquals(0, sext.getT1());
+    assertEquals(1, sext.getT2());
+    assertEquals(2, sext.getT3());
+    assertEquals(3, sext.getT4());
+    assertEquals(4, sext.getT5());
+    assertEquals(5, sext.getT6());
+  }
+
+  @Test
+  public void testToString() {
+    final Sext sext = new Sext(0, 1, 2, 3, 4, 5);
+
+    assertEquals("Sext{t1=0, t2=1, t3=2, t4=3, t5=4, t6=5}", sext.toString());
+  }
+}

--- a/src/test/java/junit/org/rapidpm/frp/model/SingleTest.java
+++ b/src/test/java/junit/org/rapidpm/frp/model/SingleTest.java
@@ -1,0 +1,43 @@
+package junit.org.rapidpm.frp.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.rapidpm.frp.model.Single;
+
+public class SingleTest {
+
+  @Test
+  public void testEquals() {
+    final Single single = new Single(0);
+
+    assertFalse(single.equals(null));
+    assertTrue(single.equals(single));
+    assertTrue(single.equals(new Single(0)));
+  }
+
+  @Test
+  public void testHashCode() {
+    final Single single = new Single(0);
+
+    assertEquals(31, single.hashCode());
+  }
+
+  @Test
+  public void testNext() {
+    final Single single = Single.next(0);
+
+    assertNotNull(single);
+    assertEquals(0, single.getT1());
+  }
+
+  @Test
+  public void testToString() {
+    final Single single = new Single(0);
+
+    assertEquals("Single{t1=0}", single.toString());
+  }
+}

--- a/src/test/java/junit/org/rapidpm/frp/model/TripleTest.java
+++ b/src/test/java/junit/org/rapidpm/frp/model/TripleTest.java
@@ -1,0 +1,92 @@
+package junit.org.rapidpm.frp.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.rapidpm.frp.model.Triple;
+
+public class TripleTest {
+
+  @Test
+  public void testEquals() {
+    final Triple triple = new Triple(0, 1, 2);
+
+    assertTrue(triple.equals(triple));
+    assertFalse(triple.equals(null));
+    assertFalse(triple.equals(new Triple(null, 1, 2)));
+    assertFalse(triple.equals(new Triple(0, null, 2)));
+  }
+
+  @Test
+  public void testEqualsT1() {
+    final Triple triple = new Triple(null, 1, 2);
+
+    assertTrue(triple.equals(new Triple(null, 1, 2)));
+    assertFalse(triple.equals(new Triple(0, 1, 2)));
+  }
+
+  @Test
+  public void testEqualsT2() {
+    final Triple triple = new Triple(0, null, 2);
+
+    assertTrue(triple.equals(new Triple(0, null, 2)));
+    assertFalse(triple.equals(new Triple(0, 1, 2)));
+  }
+
+  @Test
+  public void testEqualsT3() {
+    final Triple triple = new Triple(0, 1, null);
+
+    assertTrue(triple.equals(new Triple(0, 1, null)));
+    assertFalse(triple.equals(new Triple(0, 1, 2)));
+  }
+
+  @Test
+  public void testHashCode() {
+    final Triple triple = new Triple(0, 1, 2);
+
+    assertEquals(33, triple.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT1() {
+    final Triple triple = new Triple(null, 1, 2);
+
+    assertEquals(33, triple.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT2() {
+    final Triple triple = new Triple(0, null, 2);
+
+    assertEquals(2, triple.hashCode());
+  }
+
+  @Test
+  public void testHashCodeT3() {
+    final Triple triple = new Triple(0, 1, null);
+
+    assertEquals(31, triple.hashCode());
+  }
+
+  @Test
+  public void testNext() {
+    final Triple triple = Triple.next(0, 1, 2);
+
+    assertNotNull(triple);
+    assertEquals(0, triple.getT1());
+    assertEquals(1, triple.getT2());
+    assertEquals(2, triple.getT3());
+  }
+
+  @Test
+  public void testToString() {
+    final Triple triple = new Triple(0, 1, 2);
+
+    assertEquals("Triple{t1=0, t2=1, t3=2}", triple.toString());
+  }
+}


### PR DESCRIPTION
Hi, 

I've ran your repository through the [JaCoCo](https://www.jacoco.org/jacoco/) code coverage tool, which reported that you had `38.5%` line coverage from your existing unit tests. 

From this, I've written some sample tests with the help of [Diffblue Cover](https://www.diffblue.com/opensource), for the following previously-uncovered classes:

- `org.rapidpm.frp.model.Single`
- `org.rapidpm.frp.model.Pair`
- `org.rapidpm.frp.model.Triple`
- `org.rapidpm.frp.model.Quad`
- `org.rapidpm.frp.model.Quint`
- `org.rapidpm.frp.model.Sext`
- `org.rapidpm.frp.model.Sept`

This now brings your total coverage to `58.5%`.

In addition, I found a bug with the `toString` method of `org.rapidpm.frp.model.Sext`, which has been fixed. This allows the test we have written for this method, to pass.

Hopefully, these tests will help you detect any regressions caused by future code changes. We would be grateful for any feedback you have regarding the quality of these tests.